### PR TITLE
Fix Policy definition payload 

### DIFF
--- a/src/modules/edc-demo/components/new-policy-dialog/new-policy-dialog.component.ts
+++ b/src/modules/edc-demo/components/new-policy-dialog/new-policy-dialog.component.ts
@@ -42,8 +42,8 @@ export class NewPolicyDialogComponent implements OnInit {
     }
 
     this.dialogRef.close({
-      policyDefinition: this.policyDefinition,
-      policy: this.policy
+      policy: this.policyDefinition.policy,
+      uid: this.policyDefinition.uid
     })
   }
 }


### PR DESCRIPTION
## What this PR changes/adds

Fix Policy definition payload.
The policy definition payload should contain fields: policy and uid instead of objects: policydefinition and policy

## Why it does that

We noticed that the policies created from UI have randomly generated id. The reason was that the UI sent incorrect payload:
```
{
    "policyDefinition": {
        "policy": {
            "type": "SET"
        },
        "uid": "3e64f8bc-0631-41d4-beaf-3eb583f292fd"
    },
    "policy": {
        "type": "SET"
    }
}
```

instead of 
```
{
    "uid": "3e64f8bc-0631-41d4-beaf-3eb583f292fd",
    "policy": {
        "type": "SET"
    }
}
```

## Linked Issue(s)

https://github.com/agera-edc/MinimumViableDataspace/issues/194

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/datadashboard/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/datadashboard/blob/main/styleguide.md) for details_)
